### PR TITLE
allow for 8 packages to subscribe

### DIFF
--- a/osdk-core/api/inc/dji_subscription.hpp
+++ b/osdk-core/api/inc/dji_subscription.hpp
@@ -358,7 +358,7 @@ public: // public methods
   }
 
 public: // public variables
-  const static uint8_t   MAX_NUMBER_OF_PACKAGE = 7;
+  const static uint8_t   MAX_NUMBER_OF_PACKAGE = 8;
   VehicleCallBackHandler subscriptionDataDecodeHandler;
 
 private: // private variables


### PR DESCRIPTION
One needs 1 package for 400, 200, 100, and 1 Hz each and
2 packages for 50 and 5 Hz each, makes for a total of 8 packages.

All topics with 50 Hz together are larger than the maximum of
250 bytes per package, therefore two packages are needed.

5 Hz contains GPS and RTK but RTK might not be available,
therefore it requires and extra package to test the availibility.